### PR TITLE
perform async queries

### DIFF
--- a/ZenPacks/zenoss/CalculatedPerformance/ReadThroughCache.py
+++ b/ZenPacks/zenoss/CalculatedPerformance/ReadThroughCache.py
@@ -110,12 +110,16 @@ class ReadThroughCache(object):
         else:
             self._cache = {}
 
-    def put(self, datasource, datapoint, rra, targetValue, value):
+    def put(self, datasource, datapoint, rra, targetPath, targetID, value):
         """
         Place a value in the rrd cache
         """
-        rrdcachekey = self._getKey(datasource, datapoint, rra, targetValue)
+        val = targetPath
+        if self._targetKey=="uuid":
+            val = targetID
+        rrdcachekey = self._getKey(datasource, datapoint, rra, val)
         self._cache[rrdcachekey] = value
+
 
 class RRDReadThroughCache(ReadThroughCache):
     def __init__(self):

--- a/ZenPacks/zenoss/CalculatedPerformance/dsplugins.py
+++ b/ZenPacks/zenoss/CalculatedPerformance/dsplugins.py
@@ -453,7 +453,7 @@ class DerivedDataSourceProxyingPlugin(PythonDataSourcePlugin):
         # if we are able prefetch all the metrics that we can
         if hasattr(self.rrdcache, "batchFetchMetrics"):
             datasources = [datasourcesByKey.get(ds) for ds in toposort(datasourceDependencies) if datasourcesByKey.get(ds)]
-            self.rrdcache.batchFetchMetrics(datasources)
+            yield self.rrdcache.batchFetchMetrics(datasources)
 
         startCollectTime = time.time()
         from collections import defaultdict
@@ -464,6 +464,7 @@ class DerivedDataSourceProxyingPlugin(PythonDataSourcePlugin):
                'datasourceClassName' not in datasource.params or \
                datasource.params['datasourceClassName'] not in DerivedProxyMap:
                 #Not our datasource, it's a dependency from elsewhere
+                #log.warn("not using ds: %s %s %s", dskey, datasource, datasource.params.__dict__)
                 continue
 
             collectionTime = time.time()

--- a/ZenPacks/zenoss/CalculatedPerformance/dsplugins.py
+++ b/ZenPacks/zenoss/CalculatedPerformance/dsplugins.py
@@ -485,11 +485,12 @@ class DerivedDataSourceProxyingPlugin(PythonDataSourcePlugin):
                                           '_'.join((datasource.datasource, p.id)) in resultValues)
 
                     for datapoint in collectedPoints:
-                        myPath = datapoint.rrdPath.rsplit('/', 1)[0]
+                        rrdPath = datapoint.rrdPath.rsplit('/', 1)[0]
+                        contextUUID = datapoint.metadata["contextUUID"]
                         value = (resultValues.get(datapoint.id, None) or
                                  resultValues.get('_'.join((datasource.datasource, datapoint.id))))[0]
                         for rra in ('AVERAGE', 'MIN', 'MAX', 'LAST'):
-                            self.rrdcache.put(datasource.datasource, datapoint.id, rra, myPath, value)
+                            self.rrdcache.put(datasource.datasource, datapoint.id, rra, rrdPath, contextUUID, value)
 
                 #incorporate results returned from the proxied method
                 collectedEvents.extend(dsResult.get('events', []))


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-18309

DEMO:
```
# plu@plu-9: serviced service attach zenpython tail -F /opt/zenoss/log/zenpython.log
2015-06-30 21:22:27,010 INFO zen.zenpython: Connecting to localhost:8789
2015-06-30 21:22:27,018 INFO zen.zenpython: Connected to ZenHub
2015-06-30 21:22:27,026 INFO zen.maintenance: Performing periodic maintenance
2015-06-30 21:22:27,026 INFO zen.zenpython: Counter eventCount, value 2602



2015-06-30 21:23:27,026 INFO zen.zenpython: 1 devices processed (28 datapoints)
2015-06-30 21:23:27,026 INFO zen.collector.scheduler: Tasks: 2 Successful_Runs: 1 Failed_Runs: 0 Missed_Runs: 0 Queued_Tasks: 0 Running_Tasks: 0 
2015-06-30 21:24:27,026 INFO zen.zenpython: 1 devices processed (46 datapoints)
2015-06-30 21:24:27,026 INFO zen.collector.scheduler: Tasks: 2 Successful_Runs: 1 Failed_Runs: 0 Missed_Runs: 0 Queued_Tasks: 0 Running_Tasks: 0 
2015-06-30 21:25:27,026 INFO zen.zenpython: 1 devices processed (64 datapoints)
2015-06-30 21:25:27,026 INFO zen.collector.scheduler: Tasks: 2 Successful_Runs: 1 Failed_Runs: 0 Missed_Runs: 0 Queued_Tasks: 0 Running_Tasks: 0 
2015-06-30 21:26:27,026 INFO zen.zenpython: 1 devices processed (97 datapoints)
2015-06-30 21:26:27,026 INFO zen.collector.scheduler: Tasks: 2 Successful_Runs: 2 Failed_Runs: 0 Missed_Runs: 0 Queued_Tasks: 0 Running_Tasks: 0 
2015-06-30 21:27:27,026 INFO zen.zenpython: 1 devices processed (115 datapoints)
2015-06-30 21:27:27,026 INFO zen.collector.scheduler: Tasks: 2 Successful_Runs: 2 Failed_Runs: 0 Missed_Runs: 0 Queued_Tasks: 0 Running_Tasks: 0 
2015-06-30 21:27:27,038 INFO zen.maintenance: Performing periodic maintenance
2015-06-30 21:27:27,039 INFO zen.zenpython: Counter eventCount, value 2602
2015-06-30 21:28:27,026 INFO zen.zenpython: 1 devices processed (134 datapoints)
2015-06-30 21:28:27,026 INFO zen.collector.scheduler: Tasks: 2 Successful_Runs: 2 Failed_Runs: 0 Missed_Runs: 0 Queued_Tasks: 0 Running_Tasks: 0 
2015-06-30 21:29:27,026 INFO zen.zenpython: 1 devices processed (167 datapoints)
2015-06-30 21:29:27,026 INFO zen.collector.scheduler: Tasks: 2 Successful_Runs: 3 Failed_Runs: 0 Missed_Runs: 0 Queued_Tasks: 0 Running_Tasks: 0 
```

![screen shot 2015-06-30 at 16 29 29](https://cloud.githubusercontent.com/assets/2837923/8442538/3f31b980-1f45-11e5-9213-b9867f0160dd.png)

