### PR TITLE
Fix traceback when using median operation.

### DIFF
--- a/ZenPacks/zenoss/CalculatedPerformance/operations.py
+++ b/ZenPacks/zenoss/CalculatedPerformance/operations.py
@@ -85,7 +85,7 @@ avg = amean
 
 
 def median(valuemap):
-    return _median(valuemap.values(), valuemap)
+    return _median(valuemap.values()), valuemap
 
 
 def _deviations(midpointFunc, values):


### PR DESCRIPTION
Example of traceback from zenpython.log.

    ERROR zen.CalculatingPlugin: Error calculating aggregation for command1_value3: _median() takes exactly 1 argument (2 given)
    _median() takes exactly 1 argument (2 given)
    Traceback (most recent call last):
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.CalculatedPerformance-2.1.0dev103_7564edd-py2.7.egg/ZenPacks/zenoss/CalculatedPerformance/dsplugins.py", line 153, in collect
        targetValues)
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.CalculatedPerformance-2.1.0dev103_7564edd-py2.7.egg/ZenPacks/zenoss/CalculatedPerformance/dsplugins.py", line 196, in performAggregation
        result, targetValues = getattr(operations, operationId)(targetValues, *arguments)
      File "/opt/zenoss/ZenPacks/ZenPacks.zenoss.CalculatedPerformance-2.1.0dev103_7564edd-py2.7.egg/ZenPacks/zenoss/CalculatedPerformance/operations.py", line 88, in median
        return _median(valuemap.values(), valuemap)
    TypeError: _median() takes exactly 1 argument (2 given)

Fixes ZEN-19728.