### PR TITLE
Fix bogus calculations when basis counters reset.

### DIFF
--- a/ZenPacks/zenoss/CalculatedPerformance/ReadThroughCache.py
+++ b/ZenPacks/zenoss/CalculatedPerformance/ReadThroughCache.py
@@ -305,6 +305,7 @@ class MetricServiceReadThroughCache(BaseMetricServiceReadThroughCache):
             aggregator=self._aggMapping.get(rra.lower(), rra.lower()),
             rpn='',
             rate=rate,
+            rateOptions=rateOptions_for_rate(rate),
             format='%.2lf',
             tags=dict(contextUUID=[uuid]),
             name='%s' % cachekey
@@ -347,6 +348,7 @@ class WildcardMetricServiceReadThroughCache(BaseMetricServiceReadThroughCache):
             metrics[name]= dict(
                     metric=name,
                     rate=rate,
+                    rateOptions=rateOptions_for_rate(rate),
                     tags=dict(contextUUID=["*"])
             )
 
@@ -389,3 +391,11 @@ def getReadThroughCache():
         # must be 4.x
         log.debug("CalculatedPerformance is using RRDReadThroughCache")
         return RRDReadThroughCache()
+
+
+def rateOptions_for_rate(rate):
+    """Return a rateOptions dict given rate as a boolean."""
+    if rate:
+        return {'counter': True, 'resetThreshold': 1}
+    else:
+        return {}


### PR DESCRIPTION
See comments on ZEN-20694 for a full explanation.

This fix is a bit of a hack because it assumes that all DERIVE and
COUNTER datapoints are actually counters that may reset or roll over.
This means the calculated performance datasource currently can't be used
on true DERIVE datapoints where the rate of positive or negative change
is what's desired. Since those don't really exist in practice it seemed
like the smarted change to make since doing proper support of DERIVE and
COUNTER would have introduced a lot of potentially dangerous change
close to release.

Fixes ZEN-20694.