### PR TITLE
Bump PythonCollector requirement from 1.3.0 to 1.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ AUTHOR = "Zenoss"
 LICENSE = "GPLv2"
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.zenoss']
 PACKAGES = ['ZenPacks', 'ZenPacks.zenoss', 'ZenPacks.zenoss.CalculatedPerformance']
-INSTALL_REQUIRES = ['ZenPacks.zenoss.PythonCollector>=1.3.0']
+INSTALL_REQUIRES = ['ZenPacks.zenoss.PythonCollector>=1.9']
 COMPAT_ZENOSS_VERS = ">= 4.1"
 PREV_ZENPACK_NAME = ""
 # STOP_REPLACEMENTS


### PR DESCRIPTION
The ability for a plugin to change its interval was added to
PythonCollector in 1.9.0.

This is required by the change in a0128b9.

Refs ZPS-70.