### PR TITLE
Support configurable metric prefixes

### DIFF
--- a/README.html
+++ b/README.html
@@ -232,6 +232,7 @@ class RandomContentsElementPool(ElementPool):
 
 <h4 id="changes-2.3.2">2.3.2</h4>
 <ul>
+    <li>Support new contextMetric capability in Zenoss 5.2.3. (ZEN-27010)</li>
 </ul>
 
 <h4 id="changes-2.3.1">2.3.1 - 2017-03-04</h4>

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -102,6 +102,7 @@ You must create these components at modeling time like any other component. Then
 == Changes ==
 
 ;2.3.2
+* Support new contextMetric capability in Zenoss 5.2.3. (ZEN-27010)
 
 ;2.3.1 - 2017-03-04
 * Clarify event when aggregation operation is blank or invalid. (ZPS-71)

--- a/ZenPacks/zenoss/CalculatedPerformance/ReadThroughCache.py
+++ b/ZenPacks/zenoss/CalculatedPerformance/ReadThroughCache.py
@@ -20,9 +20,17 @@ try:
     from twisted.web.client import Agent, CookieAgent, FileBodyProducer, readBody, HTTPConnectionPool
     from twisted.web.http_headers import Headers
     from Products.ZenUtils.MetricServiceRequest import getPool
+    from Products.ZenUtils.metrics import ensure_prefix
 except ImportError:
     # Zenoss 4 won't have CookieAgent or FileBodyProducer. This is OK
     # because RRDReadThroughCache doesn't use them.
+    pass
+
+metaDataPrefix = False
+try:
+    from Products.ZenUtils.metrics import ensure_metadata_prefix
+    metaDataPrefix = True
+except ImportError:
     pass
 
 from twisted.internet.defer import inlineCallbacks
@@ -236,17 +244,7 @@ class BaseMetricServiceReadThroughCache(ReadThroughCache):
         })
 
     def _readLastValue(self, uuid, datasource, datapoint, rra='AVERAGE', rate=False, ago=300, targetConfig={}):
-        from Products.ZenUtils.metrics import ensure_prefix
-
-        metrics = []
-        if targetConfig.get('device'):
-            deviceId = targetConfig['device']['id']
-        else:
-            deviceId = targetConfig.get('id')
-        if not deviceId:
-            return None
-        name = ensure_prefix(deviceId, datasource + "_" + datapoint)
-        log.debug("should not need to fetch metric: %s %s_%s", name, uuid, datapoint)
+        log.debug("should not need to fetch metric: %s_%s",  datasource, datapoint)
 
     @inlineCallbacks
     def batchFetchMetrics(self, datasources):
@@ -260,7 +258,11 @@ class BaseMetricServiceReadThroughCache(ReadThroughCache):
 
         for ds in datasources:
             for dp in ds.points:
-                dsdpID = "%s/%s" % (dp.metadata["contextUUID"], dp.dpName)
+                if metaDataPrefix:
+                    dsdpID = ensure_prefix(dp.metadata, dp.dpName)
+                else:
+                    dsdpID = "%s/%s" % (dp.metadata["contextUUID"], dp.dpName)
+
                 if dsdpID in dsPoints:
                     log.debug("already found in ds points %s", dsdpID)
                 else:
@@ -275,16 +277,27 @@ class BaseMetricServiceReadThroughCache(ReadThroughCache):
                     # Target datapoints are what a datasource is made up of, if the
                     # target point is also a datasource datapoint that means we don't
                     # have to query for it since it will be calculated
-                    filterKey = "%s/%s_%s" % (targetConfig.get("uuid", None), dsname, datapoint)
+                    #rrdpath in target config is json string of metricmetadata
+                    metricMeta = json.loads(targetConfig.get('rrdpath', "{}"))
+                    dpName = "%s_%s" % (dsname, datapoint)
+                    if metaDataPrefix:
+                        filterKey = ensure_prefix(metricMeta, dpName)
+                    else:
+                        filterKey = "%s/%s_%s" % (targetConfig.get("uuid", None), dsname, datapoint)
+
                     if filterKey in dsPoints:
                         log.debug("skipping target datapoint %s, since also a datasource datapoint", filterKey)
                         continue
                     cachekey = self._getKey(dsname, datapoint, rra, targetValue)
-                    if not targetConfig.get('device'):
-                        deviceId = targetConfig.get('id')
+                    if metaDataPrefix:
+                        name = ensure_prefix(metricMeta, dpName)
                     else:
-                        deviceId = targetConfig['device']['id']
-                    name = ensure_prefix(deviceId, dsname + "_" + datapoint)
+                        if not targetConfig.get('device'):
+                            deviceId = targetConfig.get('id')
+                        else:
+                            deviceId = targetConfig['device']['id']
+                        name = ensure_prefix(deviceId, dsname + "_" + datapoint)
+
                     dsclassname = datasource.params['datasourceClassName']
                     sourcetypes[dsclassname] += 1
                     self._insert_key(metrics, name, rra, rate, uuid, cachekey)
@@ -453,15 +466,15 @@ class WildcardMetricServiceReadThroughCache(BaseMetricServiceReadThroughCache):
         results = json.loads(response)['series']
         log.debug("Success retrieving %s results", len(results))
         for row in results:
-            metricName = row["metric"]
+            metricName = row["metric"].rsplit("/", 1)[-1]
             contextUUID = row["tags"]["contextUUID"]
             device = row["tags"]["device"]
-            cacheKey = "%s/%s_AVERAGE" % (contextUUID, metricName.replace("%s/"%device, ""))
+            cacheKey = "%s/%s_AVERAGE" % (contextUUID, metricName)
             if row.get('datapoints'):
                 self._cache[cacheKey] = row.get('datapoints')[0][1]
             else:
                 # put an entry so we don't fetch it again
-                self._cache[cacheKey] = None
+                self._cache.setdefault(cacheKey, None)
                 log.debug("unable to cache %s", cacheKey)
         return len(results)
 


### PR DESCRIPTION
This accomodates the read side for components that return True from
their contextMetric method.

Fixes ZEN-27010 in support of ZEN-27003.

Signed-off-by: Chet Luther <chet.luther@gmail.com>