### PR TITLE
Fix unit tests

### DIFF
--- a/ZenPacks/zenoss/CalculatedPerformance/tests/testRRDReadThroughCache.py
+++ b/ZenPacks/zenoss/CalculatedPerformance/tests/testRRDReadThroughCache.py
@@ -42,7 +42,7 @@ class TestRRDReadThroughCache(BaseTestCase):
         self.assertIn(testKey, cache._cache)
         self.assertEqual(
             cache.getLastValue(
-                'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1})[0],
+                'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1}),
             42.0)
 
     def testGetLastValue(self):
@@ -52,13 +52,13 @@ class TestRRDReadThroughCache(BaseTestCase):
         self.assertNotIn(testKey, cache._cache)
         self.assertEqual(
             cache.getLastValue(
-                'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1})[0][0], 
+                'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1}),
             54.11)
         self.assertIn(testKey, cache._cache)
         cache._readLastValue = mockReturnValue(65.43)
         self.assertEqual(
             cache.getLastValue(
-                'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1})[0][0], 
+                'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1}),
             54.11)
 
     def testGetLastValues(self):
@@ -75,7 +75,7 @@ class TestRRDReadThroughCache(BaseTestCase):
 
         expectedValues = cache.getLastValues('ds', 'dp', 'rra', False, 1, targets)[0]
         self.assertDictEqual(
-            {k: v[0][0] for k, v in expectedValues.iteritems()},
+            {k: v for k, v in expectedValues.iteritems()},
             {'1': 54.11, '2': 54.11})
 
         for testKey in testKeys:
@@ -84,13 +84,13 @@ class TestRRDReadThroughCache(BaseTestCase):
         cache._readLastValue = mockReturnValue(65.43)
         expectedValues = cache.getLastValues('ds', 'dp', 'rra', False, 1, targets)[0]
         self.assertDictEqual(
-            {k: v[0][0] for k, v in expectedValues.iteritems()},
+            {k: v for k, v in expectedValues.iteritems()},
             {'1': 54.11, '2': 54.11})
 
         cache._readLastValue = mockReturnValue(None)
         expectedValues = cache.getLastValues('ds', 'dp', 'rra', False, 1, targets)[0]
         self.assertDictEqual(
-            {k: v[0][0] for k, v in expectedValues.iteritems()},
+            {k: v for k, v in expectedValues.iteritems()},
             {'1': 54.11, '2': 54.11})
 
     def testInvalidate(self):
@@ -110,7 +110,7 @@ class TestRRDReadThroughCache(BaseTestCase):
         cache._readLastValue = mockReturnValue(54.11)
         self.assertEqual(
             cache.getLastValue(
-                'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1})[0][0], 
+                'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1}),
             54.11)
         self.assertIn(testKey, cache._cache)
         cache.invalidate(testKey)
@@ -118,7 +118,7 @@ class TestRRDReadThroughCache(BaseTestCase):
 
         self.assertEqual(
             cache.getLastValue(
-                'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1})[0][0],
+                'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1}),
             54.11)
         self.assertIn(testKey, cache._cache)
         cache.invalidate()


### PR DESCRIPTION
Fix unit tests to work after be5a3c8 commit. Subsequent to that change
the following unit tests errors were occurring due to a change in how
the cache was used.

    Error in test testGetLastValue (ZenPacks.zenoss.CalculatedPerformance.tests.testRRDReadThroughCache.TestRRDReadThroughCache)
    Traceback (most recent call last):
      File "/usr/lib64/python2.7/unittest/case.py", line 369, in run
        testMethod()
      File "/mnt/src/ZenPacks.zenoss.CalculatedPerformance/ZenPacks/zenoss/CalculatedPerformance/tests/testRRDReadThroughCache.py", line 55, in testGetLastValue
        'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1})[0][0],
    TypeError: 'float' object has no attribute '__getitem__'

    Error in test testGetLastValues (ZenPacks.zenoss.CalculatedPerformance.tests.testRRDReadThroughCache.TestRRDReadThroughCache)
    Traceback (most recent call last):
      File "/usr/lib64/python2.7/unittest/case.py", line 369, in run
        testMethod()
      File "/mnt/src/ZenPacks.zenoss.CalculatedPerformance/ZenPacks/zenoss/CalculatedPerformance/tests/testRRDReadThroughCache.py", line 78, in testGetLastValues
        {k: v[0][0] for k, v in expectedValues.iteritems()},
      File "/mnt/src/ZenPacks.zenoss.CalculatedPerformance/ZenPacks/zenoss/CalculatedPerformance/tests/testRRDReadThroughCache.py", line 78, in <dictcomp>
        {k: v[0][0] for k, v in expectedValues.iteritems()},
    TypeError: 'float' object has no attribute '__getitem__'

    Error in test testInvalidate (ZenPacks.zenoss.CalculatedPerformance.tests.testRRDReadThroughCache.TestRRDReadThroughCache)
    Traceback (most recent call last):
      File "/usr/lib64/python2.7/unittest/case.py", line 369, in run
        testMethod()
      File "/mnt/src/ZenPacks.zenoss.CalculatedPerformance/ZenPacks/zenoss/CalculatedPerformance/tests/testRRDReadThroughCache.py", line 113, in testInvalidate
        'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1})[0][0],
    TypeError: 'float' object has no attribute '__getitem__'

    Error in test testPut (ZenPacks.zenoss.CalculatedPerformance.tests.testRRDReadThroughCache.TestRRDReadThroughCache)
    Traceback (most recent call last):
      File "/usr/lib64/python2.7/unittest/case.py", line 369, in run
        testMethod()
      File "/mnt/src/ZenPacks.zenoss.CalculatedPerformance/ZenPacks/zenoss/CalculatedPerformance/tests/testRRDReadThroughCache.py", line 45, in testPut
        'ds', 'dp', 'rra', False, 1, {'rrdpath': 'perf/path', 'uuid': 1})[0],
    TypeError: 'float' object has no attribute '__getitem__'

      Ran 28 tests with 0 failures and 4 errors in 24.891 seconds.

    Tests with errors:
       testGetLastValue (ZenPacks.zenoss.CalculatedPerformance.tests.testRRDReadThroughCache.TestRRDReadThroughCache)
       testGetLastValues (ZenPacks.zenoss.CalculatedPerformance.tests.testRRDReadThroughCache.TestRRDReadThroughCache)
       testInvalidate (ZenPacks.zenoss.CalculatedPerformance.tests.testRRDReadThroughCache.TestRRDReadThroughCache)
       testPut (ZenPacks.zenoss.CalculatedPerformance.tests.testRRDReadThroughCache.TestRRDReadThroughCache)