### PR TITLE
Change useBasisInterval to use configured interval

### DIFF
--- a/README.html
+++ b/README.html
@@ -255,6 +255,11 @@ class RandomContentsElementPool(ElementPool):
 
 <h2 id="changes">Changes</h2>
 
+<h4 id="changes-2.4.2">2.4.2</h4>
+<ul>
+    <li>Use configured cycletime of basis datasources for "Use Basis Interval". (ZPS-2077)</li>
+</ul>
+
 <h4 id="changes-2.4.0">2.4.0</h4>
 <ul>
     <li>Add "Use Basis Interval" option to all datasource types. (ZPS-1134)</li>

--- a/ZenPacks/zenoss/CalculatedPerformance/ReadThroughCache.py
+++ b/ZenPacks/zenoss/CalculatedPerformance/ReadThroughCache.py
@@ -5,7 +5,7 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 
-from collections import defaultdict, deque
+from collections import defaultdict
 from datetime import datetime, timedelta
 
 import time
@@ -105,7 +105,6 @@ class ReadThroughCache(object):
 
     def __init__(self):
         self._cache = {}
-        self._timestampCache = defaultdict(deque)
 
     def _getKey(self, datasource, datapoint, rra, targetValue):
         return '%s/%s_%s_%s' % (targetValue, datasource, datapoint, rra)
@@ -204,46 +203,6 @@ class ReadThroughCache(object):
             val = targetID
         cacheKey = self._getKey(datasource, datapoint, rra, val)
         self._cache[cacheKey] = value
-
-    @property
-    def timestampCache(self):
-        """Return the timestamp cache.
-
-        Representation of the timestamp cache:
-            defaultdict(<type 'collections.deque'>, {
-                u'cbe42e3a-7099-465d-9065-12f1478c5a94/basis_twenty_AVERAGE': deque([1490692848, 1490692868]), 
-                u'649c8bbb-30c1-4925-9253-66a69dc00f4d/basis_twenty_AVERAGE': deque([1490692857, 1490692877]), 
-                u'6f23612e-58aa-4652-b753-cc4957a48f20/basis_twenty_AVERAGE': deque([1490692857, 1490692877]), 
-                u'79c14b21-23c0-462c-a2a8-43c541fe7ba7/basis_twenty_AVERAGE': deque([1490692881, 1490692891]), 
-                u'bcb3e877-8e67-4464-9615-eaa08276f537/basis_twenty_AVERAGE': deque([1490692847, 1490692867]),})
-
-        """
-        return self._timestampCache
-
-    def cacheTimestamp(self, cacheKey, newTimestamp):
-        """Put a new timestamp to the timestamp cache.
-
-        Args:
-            cacheKey (str): A combination of target UUID, 
-                datasource, datapoint and RRA.
-            newTimestamp (int): The last collection timestamp 
-                for the cacheKey.
-
-        """
-        if cacheKey in self._timestampCache:
-            cachedTimestamps = self._timestampCache[cacheKey]
-            if cachedTimestamps:
-                # Don't add duplicates.
-                if newTimestamp in cachedTimestamps:
-                    return None
-                # Check whether we already have the timestamps for 
-                # the last and previous collection cycles regarding the cacheKey, 
-                # so, we can remove the previous collection timestamp and move
-                # the last collection timestamp to the previous position.
-                if len(cachedTimestamps) > 1:
-                    self._timestampCache[cacheKey].popleft()
-        # Cache the last collection timestamp for the cacheKey.
-        self._timestampCache[cacheKey].append(newTimestamp)
 
 
 class RRDReadThroughCache(ReadThroughCache):
@@ -483,11 +442,9 @@ class MetricServiceReadThroughCache(BaseMetricServiceReadThroughCache):
         for row in results:
             if row.get('datapoints'):
                 value = row.get('datapoints')[0]['value']
-                timestamp = row.get('datapoints')[0]['timestamp']
-                # row['metric'] is a combination of UUID, 
+                # row['metric'] is a combination of UUID,
                 # datasource, datapoint and RRA. 
                 self._cache[row['metric']] = value
-                self.cacheTimestamp(row['metric'], timestamp)
                 log.debug("cached %s: %s", row['metric'], self._cache[row['metric']])
             else:
                 # put an entry so we don't fetch it again
@@ -530,9 +487,7 @@ class WildcardMetricServiceReadThroughCache(BaseMetricServiceReadThroughCache):
             cacheKey = "%s/%s_AVERAGE" % (contextUUID, metricName)
             if row.get('datapoints'):
                 value = row.get('datapoints')[0][1]
-                timestamp = row.get('datapoints')[0][0]
                 self._cache[cacheKey] = value
-                self.cacheTimestamp(cacheKey, timestamp)
             else:
                 # put an entry so we don't fetch it again
                 self._cache.setdefault(cacheKey, None)

--- a/ZenPacks/zenoss/CalculatedPerformance/dsplugins.py
+++ b/ZenPacks/zenoss/CalculatedPerformance/dsplugins.py
@@ -19,8 +19,7 @@ from Products.ZenEvents import ZenEventClasses
 from Products.ZenModel.DeviceComponent import DeviceComponent
 from Products.ZenUtils.Utils import monkeypatch
 from Products.Zuul import IInfo
-from ZenPacks.zenoss.CalculatedPerformance import (
-    operations, USE_BASIS_INTERVAL, MINIMUM_INTERVAL, MAXIMUM_INTERVAL,)
+from ZenPacks.zenoss.CalculatedPerformance import operations
 from ZenPacks.zenoss.CalculatedPerformance.ReadThroughCache import getReadThroughCache
 from ZenPacks.zenoss.CalculatedPerformance.utils import toposort, grouper, dotTraverse, getVarNames, createDeviceDictionary, dsKey
 from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
@@ -82,68 +81,6 @@ def handleArguments(targetArgValues, dpargs):
     return arguments
 
 
-def getCollectionInterval(timestamps, minimumInterval, maximumInterval):
-    """Determine the collection interval based on delta
-    between the last and previous data collection.
-
-    Args:
-        timestamps (list): A list of two timestamps, 
-            the first values is the previous collection timestamp and 
-            the second values is the last collection timestamp.
-        minimumInterval (int or None): The lowest possible value 
-            for the interval.
-        maximumInterval (int or None): The highest possible value 
-            for the interval.
-
-    Returns:
-        int: A collection interval.
-
-    """
-    previousCollectionTime = timestamps[0]
-    lastCollectionTime = timestamps[1]
-    interval = lastCollectionTime - previousCollectionTime
-    minimum = interval if minimumInterval is None else minimumInterval
-    maximum = interval if maximumInterval is None else maximumInterval
-    return max(1, max(min(maximum, interval), minimum))
-
-
-def getCollectionIntervals(timestampCache, targets, 
-                           targetDatasource, targetDatapoint, targetRRA,
-                           minimumInterval, maximumInterval):
-    """Determine the collection intervals for a particular datasource 
-    based on its basis datapoints.
-
-    Args:
-        timestampCache (defaultdict): A cache with timestamps. 
-        targets (list): A list of components to be processed.
-        targetDatasource (str): Base datasource.
-        targetDatapoint (str): Base datapoint.
-        targetRRA (str): Round Robin Archive, AVERAGE by default.
-        minimumInterval (int or None): The lowest possible value 
-            for the interval.
-        maximumInterval (int or None): The highest possible value 
-            for the interval.
-
-    Returns:
-        list: The collection intervals.
-
-    """
-    intervals = []
-    for target in targets:
-        targetUUID = target['uuid']
-        if not targetUUID:
-            continue
-        cacheKey = "{0}/{1}_{2}_{3}".format(
-            targetUUID, targetDatasource, targetDatapoint, targetRRA)
-        timestamps = timestampCache.get(cacheKey)
-        if timestamps and len(timestamps) > 1:
-            interval = getCollectionInterval(
-                timestamps, minimumInterval, maximumInterval)
-            if interval:
-                intervals.append(interval)
-    return intervals
-
-
 class AggregatingDataSourcePlugin(object):
 
     @classmethod
@@ -171,9 +108,6 @@ class AggregatingDataSourcePlugin(object):
             targetArgValues=[tuple(targetArgValues)],
             targets=targetInfos,
             debug=datasource.debug or zDebug,
-            useBasisInterval=datasource.useBasisInterval,
-            minimumInterval=datasource.minimumInterval,
-            maximumInterval=datasource.maximumInterval
         )
 
     @inlineCallbacks
@@ -182,12 +116,6 @@ class AggregatingDataSourcePlugin(object):
         collectedValues = {}
         data = {}
         debug = datasource.params.get('debug', None)
-        useBasisInterval = datasource.params.get(
-            'useBasisInterval', USE_BASIS_INTERVAL)
-        minimumInterval = datasource.params.get(
-            'minimumInterval', MINIMUM_INTERVAL)
-        maximumInterval = datasource.params.get(
-            'maximumInterval', MAXIMUM_INTERVAL)
 
         #Aggregate datasources only have one target datapoint config
         targetDatasource, targetDatapoint, targetRRA, targetAsRate = datasource.params['targetDatapoints'][0]
@@ -219,20 +147,6 @@ class AggregatingDataSourcePlugin(object):
                 'events': collectedEvents,
                 'values': collectedValues,
             })
-
-        if useBasisInterval:
-            targets = datasource.params.get('targets', [])
-            collectionIntervals = getCollectionIntervals(
-                rrdcache.timestampCache,
-                targets,
-                targetDatasource,
-                targetDatapoint,
-                targetRRA,
-                minimumInterval,
-                maximumInterval)
-
-            if collectionIntervals:
-                data['interval'] = min(collectionIntervals)
 
         for datapoint in datasource.points:
             try:
@@ -332,9 +246,6 @@ class CalculatedDataSourcePlugin(object):
             'expression': datasource.expression,
             'debug': datasource.debug or zDebug,
             'template': datasource.rrdTemplate().getPrimaryId(),
-            'useBasisInterval': datasource.useBasisInterval,
-            'minimumInterval': datasource.minimumInterval,
-            'maximumInterval': datasource.maximumInterval
         }
 
         attrs = {}
@@ -371,15 +282,8 @@ class CalculatedDataSourcePlugin(object):
     def collect(self, config, datasource, rrdcache, collectionTime):
         collectedEvents = []
         collectedValues = {}
-        collectionIntervals = []
         expression = datasource.params.get('expression', None)
         debug = datasource.params.get('debug', None)
-        useBasisInterval = datasource.params.get(
-            'useBasisInterval', USE_BASIS_INTERVAL)
-        minimumInterval = datasource.params.get(
-            'minimumInterval', MINIMUM_INTERVAL)
-        maximumInterval = datasource.params.get(
-            'maximumInterval', MAXIMUM_INTERVAL)
 
         if expression:
             # We will populate this with perf metrics and pass to eval()
@@ -433,18 +337,6 @@ class CalculatedDataSourcePlugin(object):
                 if value is None:
                     gotAllRRDValues = False
                 else:
-                    if useBasisInterval:
-                        targets = datasource.params.get('targets', [])
-                        collectionIntervals.extend(
-                            getCollectionIntervals(
-                                rrdcache.timestampCache,
-                                targets,
-                                targetDatasource,
-                                targetDatapoint,
-                                targetRRA,
-                                minimumInterval,
-                                maximumInterval))
-
                     fqdpn = '%s_%s' % (targetDatasource, targetDatapoint)
 
                     # Syntax 1
@@ -503,9 +395,6 @@ class CalculatedDataSourcePlugin(object):
         data = {
             'events': collectedEvents,
             'values': collectedValues,}
-
-        if collectionIntervals:
-            data['interval'] = min(collectionIntervals)
 
         returnValue(data)
 
@@ -569,7 +458,6 @@ class DerivedDataSourceProxyingPlugin(PythonDataSourcePlugin):
         collectedEvents = []
         collectedValues = {}
         collectedMaps = []
-        collectedIntervals = []
 
         datasourcesByKey = {dsKey(ds): ds for ds in config.datasources}
         # if we are able prefetch all the metrics that we can
@@ -627,10 +515,6 @@ class DerivedDataSourceProxyingPlugin(PythonDataSourcePlugin):
                 dsclassname = datasource.params['datasourceClassName']
                 sourcetypes[dsclassname] += 1
 
-                interval = dsResult.get('interval')
-                if interval:
-                    collectedIntervals.append(interval)
-
         endCollectTime = time.time()
         timeTaken = endCollectTime - startCollectTime
         timeLogFn = log.debug
@@ -642,9 +526,6 @@ class DerivedDataSourceProxyingPlugin(PythonDataSourcePlugin):
             'events': collectedEvents,
             'values': collectedValues,
             'maps': collectedMaps,}
-
-        if collectedIntervals:
-            data['interval'] = min(collectedIntervals)
 
         returnValue(data)
 

--- a/ZenPacks/zenoss/CalculatedPerformance/tests/testAggregatingDataSource.py
+++ b/ZenPacks/zenoss/CalculatedPerformance/tests/testAggregatingDataSource.py
@@ -1,0 +1,109 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Tests for CalculatedPerformanceDataSource."""
+
+# Zenoss Imports
+from Products.ZenModel.BasicDataSource import BasicDataSource
+from Products.ZenModel.FileSystem import FileSystem
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+# PythonCollector Imports
+from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
+    import PythonDataSource
+
+# CalculatedPerformance Imports
+from ZenPacks.zenoss.CalculatedPerformance.datasources.AggregatingDataSource \
+    import AggregatingDataSource
+
+
+class TestAggregatingDataSource(BaseTestCase):
+
+    """Test suite for CalculatedPerformanceDataSource."""
+
+    def test_getCycleTime(self):
+        deviceclass = self.dmd.Devices.createOrganizer("/Test/CalculatedPerformance")
+        deviceclass.setZenProperty("zCollectorClientTimeout", 20)
+
+        # Basis datasources.
+        deviceclass.manage_addRRDTemplate("FileSystem")
+        basis_template = deviceclass.rrdTemplates._getOb("FileSystem")
+
+        command_ds = BasicDataSource("command")
+        basis_template.datasources._setObject(command_ds.id, command_ds)
+        command_ds = basis_template.datasources._getOb(command_ds.id)
+        command_ds.sourcetype = "COMMAND"
+        command_ds.cycletime = 10
+        command_ds.manage_addRRDDataPoint("command")
+
+        python_ds = PythonDataSource("python")
+        basis_template.datasources._setObject(python_ds.id, python_ds)
+        python_ds = basis_template.datasources._getOb(python_ds.id)
+        python_ds.cycletime = "${here/zCollectorClientTimeout}"
+        python_ds.manage_addRRDDataPoint("python")
+
+        # Aggregating datasources.
+        deviceclass.manage_addRRDTemplate("Device")
+        agg_template = deviceclass.rrdTemplates._getOb("Device")
+
+        agg_ds1 = AggregatingDataSource("agg1")
+        agg_template.datasources._setObject(agg_ds1.id, agg_ds1)
+        agg_ds1 = agg_template.datasources._getOb(agg_ds1.id)
+        agg_ds1.targetMethod = "os.filesystems"
+        agg_ds1.targetDataSource = "command"
+        agg_ds1.targetDataPoint = "command"
+        agg_ds1.useBasisInterval = False
+        agg_ds1.cycletime = 30
+
+        agg_ds2 = AggregatingDataSource("agg2")
+        agg_template.datasources._setObject(agg_ds2.id, agg_ds2)
+        agg_ds2 = agg_template.datasources._getOb(agg_ds2.id)
+        agg_ds2.targetMethod = "os.filesystems"
+        agg_ds2.targetDataSource = "python"
+        agg_ds2.targetDataPoint = "python"
+        agg_ds2.useBasisInterval = True
+        agg_ds2.cycletime = 40
+
+        # Device
+        device = deviceclass.createInstance("TestCalculatedPerformance")
+        device.setPerformanceMonitor("localhost")
+
+        # Members
+        fs1 = FileSystem("boot")
+        device.os.filesystems._setObject(fs1.id, fs1)
+        fs2 = FileSystem("root")
+        device.os.filesystems._setObject(fs2.id, fs2)
+
+        # Sanity checks.
+        self.assertEqual(command_ds.cycletime, 10)
+        self.assertEqual(python_ds.getCycleTime(device), 20)
+
+        # useBasisInterval = False
+        self.assertEqual(agg_ds1.getCycleTime(device), 30)
+
+        # useBasisInterval = True
+        self.assertEqual(agg_ds2.getCycleTime(device), 20)
+
+        # minimumInterval
+        agg_ds2.minimumInterval = None
+        self.assertEqual(agg_ds2.getCycleTime(device), 20)
+        agg_ds2.minimumInterval = 1
+        self.assertEqual(agg_ds2.getCycleTime(device), 20)
+        agg_ds2.minimumInterval = 40
+        self.assertEqual(agg_ds2.getCycleTime(device), 40)
+        agg_ds2.minimumInterval = None
+
+        # maximumInterval
+        agg_ds2.maximumInterval = None
+        self.assertEqual(agg_ds2.getCycleTime(device), 20)
+        agg_ds2.maximumInterval = 40
+        self.assertEqual(agg_ds2.getCycleTime(device), 20)
+        agg_ds2.maximumInterval = 1
+        self.assertEqual(agg_ds2.getCycleTime(device), 1)
+        agg_ds2.maximumInterval = None

--- a/ZenPacks/zenoss/CalculatedPerformance/tests/testCalculatedPerformanceDataSource.py
+++ b/ZenPacks/zenoss/CalculatedPerformance/tests/testCalculatedPerformanceDataSource.py
@@ -1,0 +1,97 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Tests for CalculatedPerformanceDataSource."""
+
+# Zenoss Imports
+from Products.ZenModel.BasicDataSource import BasicDataSource
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+# PythonCollector Imports
+from ZenPacks.zenoss.PythonCollector.datasources.PythonDataSource \
+    import PythonDataSource
+
+# CalculatedPerformance Imports
+from ZenPacks.zenoss.CalculatedPerformance.datasources.CalculatedPerformanceDataSource \
+    import CalculatedPerformanceDataSource
+
+
+class TestCalculatedPerformanceDataSource(BaseTestCase):
+
+    """Test suite for CalculatedPerformanceDataSource."""
+
+    def test_getCycleTime(self):
+        deviceclass = self.dmd.Devices.createOrganizer("/Test/CalculatedPerformance")
+        deviceclass.setZenProperty("zCollectorClientTimeout", 20)
+
+        deviceclass.manage_addRRDTemplate("Device")
+        template = deviceclass.rrdTemplates._getOb("Device")
+
+        # Basis datasources.
+        basis_datasource1 = BasicDataSource("basis1")
+        template.datasources._setObject(basis_datasource1.id, basis_datasource1)
+        basis_datasource1 = template.datasources._getOb(basis_datasource1.id)
+        basis_datasource1.sourcetype = "COMMAND"
+        basis_datasource1.cycletime = 10
+        basis_datasource1.manage_addRRDDataPoint("basis1")
+
+        basis_datasource2 = PythonDataSource("basis2")
+        template.datasources._setObject(basis_datasource2.id, basis_datasource2)
+        basis_datasource2 = template.datasources._getOb(basis_datasource2.id)
+        basis_datasource2.cycletime = "${here/zCollectorClientTimeout}"
+        basis_datasource2.manage_addRRDDataPoint("basis2")
+
+        # Calculated datasources.
+        calculated_datasource1 = CalculatedPerformanceDataSource("calculated1")
+        template.datasources._setObject(calculated_datasource1.id, calculated_datasource1)
+        calculated_datasource1 = template.datasources._getOb(calculated_datasource1.id)
+        calculated_datasource1.expression = "basis1 + basis2"
+        calculated_datasource1.useBasisInterval = False
+        calculated_datasource1.cycletime = 30
+        calculated_datasource1.manage_addRRDDataPoint("calculated1")
+
+        calculated_datasource2 = CalculatedPerformanceDataSource("calculated2")
+        template.datasources._setObject(calculated_datasource2.id, calculated_datasource2)
+        calculated_datasource2 = template.datasources._getOb(calculated_datasource2.id)
+        calculated_datasource2.expression = "basis1 + basis2"
+        calculated_datasource2.useBasisInterval = True
+        calculated_datasource2.cycletime = 40
+        calculated_datasource2.manage_addRRDDataPoint("calculated2")
+
+        # Device
+        device = deviceclass.createInstance("TestCalculatedPerformance")
+        device.setPerformanceMonitor("localhost")
+
+        # Santity checks.
+        self.assertEqual(basis_datasource1.cycletime, 10)
+        self.assertEqual(basis_datasource2.getCycleTime(device), 20)
+
+        # useBasisInterval = False
+        self.assertEqual(calculated_datasource1.getCycleTime(device), 30)
+
+        # useBasisInterval = True
+        self.assertEqual(calculated_datasource2.getCycleTime(device), 10)
+
+        # minimumInterval
+        calculated_datasource2.minimumInterval = None
+        self.assertEqual(calculated_datasource2.getCycleTime(device), 10)
+        calculated_datasource2.minimumInterval = 1
+        self.assertEqual(calculated_datasource2.getCycleTime(device), 10)
+        calculated_datasource2.minimumInterval = 20
+        self.assertEqual(calculated_datasource2.getCycleTime(device), 20)
+        calculated_datasource2.minimumInterval = None
+
+        # maximumInterval
+        calculated_datasource2.maximumInterval = None
+        self.assertEqual(calculated_datasource2.getCycleTime(device), 10)
+        calculated_datasource2.maximumInterval = 20
+        self.assertEqual(calculated_datasource2.getCycleTime(device), 10)
+        calculated_datasource2.maximumInterval = 1
+        self.assertEqual(calculated_datasource2.getCycleTime(device), 1)
+        calculated_datasource2.maximumInterval = None


### PR DESCRIPTION
Prior to this change useBasisInterval worked in zenpython by changing
the interval of the derived (Calculated Performance & Datapoint
Aggregator) datasource collection based on the timestamps of the
previous two collections of their basis datapoints. In practice (see
ZPS-2077) this seems to result in irregular collection intervals, and
not a terribly good match to the basis intervals.

This change moves the implementation of useBasisInterval from the
collector (zenpython) into the hub config service (PythonConfig). Now
instead of looking at the difference between the previous two collection
intervals of the basis datasources, we only look at the configured
cycletime (or getCycleTime(context) when available) of the basis
datasources. This results in a perfectly predictable collection interval
for the derived datasources at a slightly higher cost when building
zenpython's configuration.

I profiled how long it takes to build the zenpython configuration for
our "ucs1" on UCS-PM 2.5.0 before and after this change.

Before this change:

    4629860 function calls (4438746 primitive calls) in 27.950 seconds

After this change:

    5657494 function calls (5398178 primitive calls) in 40.939 seconds

I haven't found a way to optimize this any further, and I believe the
additional cost is worth it. UCS-PM with large UCS devices is a rather
extreme example because the derived datapoints are nested many levels
deep, and there's a higher than normal cost to even calculate the
cycletime of the basis datapoints.

Note that for UCS this change relies on a change going into CiscoUCS
2.6.2 that implements UCSDataSource.getCycleTime to provide the true
collection interval of all UCS datasources that would be the basis
datasources in UCS-PM.

Refs ZPS-2077.